### PR TITLE
feat: add AlternateFutures deployment workflow

### DIFF
--- a/.github/workflows/af-deploy-common.yml
+++ b/.github/workflows/af-deploy-common.yml
@@ -1,0 +1,54 @@
+name: Deploy to AlternateFutures (Common)
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+      network:
+        required: false
+        type: string
+        default: ipfs
+    secrets:
+      af_api_key:
+        required: true
+
+env:
+  TARGET_ENVIRONMENT: ${{ inputs.environment }}
+  AF_API_KEY: ${{ secrets.af_api_key }}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static site
+        run: npm run build
+
+      - name: Install AlternateFutures CLI
+        run: npm install -g @alternatefutures/cli
+
+      - name: Deploy to AlternateFutures
+        run: af sites deploy out --network ${{ inputs.network }}
+        env:
+          AF_API_KEY: ${{ secrets.af_api_key }}

--- a/.github/workflows/af-deploy-production.yml
+++ b/.github/workflows/af-deploy-production.yml
@@ -1,0 +1,19 @@
+name: Deploy to AlternateFutures (Production)
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-to-production:
+    uses: ./.github/workflows/af-deploy-common.yml
+    with:
+      environment: production
+      branch: main
+      network: ipfs
+    secrets:
+      af_api_key: ${{ secrets.AF_API_KEY }}

--- a/.github/workflows/af-deploy-staging.yml
+++ b/.github/workflows/af-deploy-staging.yml
@@ -1,0 +1,18 @@
+name: Deploy to AlternateFutures (Staging)
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  deploy-to-staging:
+    uses: ./.github/workflows/af-deploy-common.yml
+    with:
+      environment: staging
+      branch: ${{ github.head_ref }}
+      network: ipfs
+    secrets:
+      af_api_key: ${{ secrets.AF_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflows for automatic deployment to AlternateFutures platform
- Site builds to static (`npm run build` → `out/` directory) and deploys to IPFS
- Production deployments trigger on push to main branch
- Staging deployments trigger on PRs

## Workflows Added
- `af-deploy-production.yml` - Production deployment on push to main
- `af-deploy-staging.yml` - Staging deployment for PRs  
- `af-deploy-common.yml` - Shared workflow logic

## Prerequisites
Before merging, configure the following repository secret:
- `AF_API_KEY` - AlternateFutures API key for deployment authentication

## Test Plan
- [ ] Configure `AF_API_KEY` secret in repository settings
- [ ] Merge PR and verify workflow triggers on main
- [ ] Verify site deploys successfully to IPFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)